### PR TITLE
## Bug Fix

### DIFF
--- a/app/src/main/java/io/github/auag0/hidemocklocation/Main.kt
+++ b/app/src/main/java/io/github/auag0/hidemocklocation/Main.kt
@@ -1,6 +1,7 @@
 package io.github.auag0.hidemocklocation
 
 import android.annotation.SuppressLint
+import android.app.AppOpsManager
 import android.os.Bundle
 import io.github.libxposed.api.XposedInterface
 import io.github.libxposed.api.XposedModule
@@ -10,6 +11,7 @@ class Main : XposedModule() {
     override fun onPackageReady(param: XposedModuleInterface.PackageReadyParam) {
         hookLocationMethods(param.classLoader)
         hookSettingsMethods(param.classLoader)
+        hookAppOpsMethods(param.classLoader)
     }
 
     @SuppressLint("SoonBlockedPrivateApi", "BlockedPrivateApi")
@@ -32,16 +34,22 @@ class Main : XposedModule() {
         }
 
         hookAllMethods(locationClass, "getExtras") { chain ->
-            var extras: Bundle? = chain.proceed() as Bundle?
-            extras = getPatchedBundle(extras)
-            return@hookAllMethods extras
+            val extras = chain.proceed() as Bundle?
+            return@hookAllMethods getPatchedBundle(extras)
         }
 
         hookAllMethods(locationClass, "setExtras") { chain ->
             val args = chain.args.toTypedArray()
-            val extras = args[0] as Bundle?
-            args[0] = getPatchedBundle(extras)
+            args[0] = getPatchedBundle(args[0] as Bundle?)
             chain.proceed(args)
+        }
+
+        // Hook getProvider() to normalize mock provider names.
+        // Known legitimate providers; anything else is treated as a mock name.
+        val knownProviders = setOf("gps", "network", "passive", "fused")
+        hookAllMethods(locationClass, "getProvider") { chain ->
+            val provider = chain.proceed() as? String ?: return@hookAllMethods null
+            if (provider !in knownProviders) "gps" else provider
         }
 
         val hasMockProviderMaskField = runCatching {
@@ -59,16 +67,14 @@ class Main : XposedModule() {
 
             if (hasMockProviderMaskField != null && mFieldsMaskField != null) {
                 val hasMockProviderMask = hasMockProviderMaskField.getInt(null)
-
                 var mFieldsMask = mFieldsMaskField.getInt(chain.thisObject)
                 mFieldsMask = mFieldsMask and hasMockProviderMask.inv()
                 mFieldsMaskField.setInt(chain.thisObject, mFieldsMask)
             }
 
             if (mExtrasField != null) {
-                var mExtras = mExtrasField.get(chain.thisObject) as? Bundle?
-                mExtras = getPatchedBundle(mExtras)
-                mExtrasField.set(chain.thisObject, mExtras)
+                val mExtras = mExtrasField.get(chain.thisObject) as? Bundle?
+                mExtrasField.set(chain.thisObject, getPatchedBundle(mExtras))
             }
         }
     }
@@ -76,25 +82,53 @@ class Main : XposedModule() {
     private fun hookSettingsMethods(classLoader: ClassLoader) {
         val clazz = classLoader.loadClass($$"android.provider.Settings$Secure")
         hookAllMethods(clazz, "getStringForUser") { chain ->
-            val args = chain.args.toTypedArray()
-            val name: String? = args[1] as? String?
-            if (name == "mock_location") {
-                return@hookAllMethods "0"
-            }
-            return@hookAllMethods chain.proceed()
+            val name = chain.args.getOrNull(1) as? String?
+            if (name == "mock_location") "0" else chain.proceed()
         }
     }
 
+    // Hook AppOpsManager check methods to hide mock location permission.
+    // Only check-type methods are hooked (not noteOp), so the mock location
+    // app itself can still record its own operations normally.
+    private fun hookAppOpsMethods(classLoader: ClassLoader) {
+        val appOpsClass = runCatching {
+            classLoader.loadClass("android.app.AppOpsManager")
+        }.getOrNull() ?: return
+
+        val checkMethods = listOf(
+            "checkOp", "checkOpNoThrow",
+            "unsafeCheckOp", "unsafeCheckOpNoThrow"
+        )
+        for (methodName in checkMethods) {
+            hookAllMethods(appOpsClass, methodName) { chain ->
+                if (isMockLocationOp(chain.args.firstOrNull())) {
+                    return@hookAllMethods AppOpsManager.MODE_ERRORED
+                }
+                chain.proceed()
+            }
+        }
+    }
+
+    // Returns a copy of the bundle with "mockLocation" forced to false,
+    // or the original bundle unchanged if the key is absent.
     private fun getPatchedBundle(origBundle: Bundle?): Bundle? {
         if (origBundle?.containsKey("mockLocation") == true) {
-            origBundle.putBoolean("mockLocation", false)
+            return Bundle(origBundle).apply { putBoolean("mockLocation", false) }
         }
         return origBundle
     }
 
+    private fun isMockLocationOp(op: Any?): Boolean = when (op) {
+        // "android:mock_location"
+        // AppOpsManager.OP_MOCK_LOCATION
+        is String -> op == AppOpsManager.OPSTR_MOCK_LOCATION
+        is Int -> op == 58
+        else -> false
+    }
+
     private fun hookAllMethods(clazz: Class<*>, methodName: String, hooker: XposedInterface.Hooker) {
         clazz.declaredMethods
-            .filter { it.name.equals(methodName) }
+            .filter { it.name == methodName }
             .forEach { method -> hook(method).intercept(hooker) }
     }
 }


### PR DESCRIPTION
### getPatchedBundle: avoid mutating the original Bundle Previously, getPatchedBundle() modified the caller's Bundle object in place via putBoolean(). If the same Bundle instance was referenced elsewhere (e.g., shared between setExtras and getExtras call chains), this could silently corrupt the caller's data. The fix creates a defensive copy via Bundle(origBundle) before patching, leaving the original untouched.

## New Features

### Hook AppOpsManager to hide mock location permission (AppOps path) Apps can detect mock location by calling AppOpsManager.checkOp() with op = "android:mock_location" (OPSTR_MOCK_LOCATION) or op = 58 (OP_MOCK_LOCATION) to check whether any app holds the mock location app-op. This is a common detection path on Android 6+.

Four check-only methods are now intercepted:
  - checkOp / checkOpNoThrow
  - unsafeCheckOp / unsafeCheckOpNoThrow

When the queried op matches MOCK_LOCATION, MODE_ERRORED is returned, making it appear as though no app holds the mock location permission.

noteOp / noteOpNoThrow are intentionally NOT hooked: those methods are called by the mock location app itself to record its own operations. Intercepting them would break the mock location provider.

### Hook Location.getProvider() to normalize suspicious provider names Mock location apps sometimes set a non-standard provider name (e.g., "mock", or an arbitrary string) when constructing Location objects. Detection apps can compare getProvider() output against the known set {"gps", "network", "passive", "fused"} to identify fakes.

getProvider() is now hooked to return "gps" whenever the actual provider name falls outside that known set.

## Refactor / Cleanup

- getStringForUser hook simplified to a single expression
- Redundant intermediate variables removed in getExtras, setExtras,   and set() hooks
- hookAllMethods filter changed from .equals() to == (idiomatic Kotlin)

---

## 缺陷修复

### getPatchedBundle：修复直接修改原始 Bundle 的问题
此前，getPatchedBundle() 通过 putBoolean() 直接在原始 Bundle 对象上 进行修改。若同一个 Bundle 实例被多处引用（例如在 setExtras 和
getExtras 调用链之间共享），可能导致调用方的数据被静默篡改。
修复方式：在修改前通过 Bundle(origBundle) 创建防御性副本，
确保原始对象不受影响。

## 新增功能

### Hook AppOpsManager，通过 AppOps 路径隐藏模拟位置权限
应用可通过调用 AppOpsManager.checkOp()，并传入
op = "android:mock_location"（OPSTR_MOCK_LOCATION）或 op = 58 （OP_MOCK_LOCATION）来检测是否有应用持有模拟位置权限。
这是 Android 6+ 上常见的检测手段。

本次新增对以下四个只读检查方法的拦截：
  - checkOp / checkOpNoThrow
  - unsafeCheckOp / unsafeCheckOpNoThrow

当查询的 op 匹配 MOCK_LOCATION 时，返回 MODE_ERRORED，
使检测方认为当前没有任何应用持有模拟位置权限。

noteOp / noteOpNoThrow 刻意未被 Hook：这两个方法由模拟位置应用
自身调用，用于记录其操作。若拦截这两个方法，会导致模拟位置
提供者无法正常工作。

### Hook Location.getProvider()，规范化可疑的 provider 名称 模拟位置应用在构造 Location 对象时，有时会设置非标准的 provider
名称（如 "mock" 或其他自定义字符串）。检测应用可将 getProvider()
的返回值与已知合法集合 {"gps", "network", "passive", "fused"} 进行比对，从而识别伪造位置。

本次 Hook 了 getProvider()，当实际 provider 名称不在上述已知集合中时， 统一返回 "gps"。

## 重构 / 清理

- getStringForUser 的 Hook 逻辑简化为单一表达式
- 移除 getExtras、setExtras 及 set() Hook 中多余的中间变量
- hookAllMethods 的过滤条件由 .equals() 改为 ==（符合 Kotlin 惯用法）